### PR TITLE
Feature incremental build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+libs
 gcc-*
 newlib-*
 gdb-*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ build
 gcc-*
 newlib-*
 gdb-*
+gmp-*
+mpc-*
 mpfr-*
 binutils-*
 arm-*

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ install-tools: cross-binutils cross-gcc cross-gdb
 .PHONY: install-cross
 install-cross: install-tools install-note
 
+.PHONY: install-deps
 install-deps: gmp mpfr mpc
 
 sudomode:

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ MOD_CONFIG	= $(BUILD_PATH)/$(1)/$(CONFIG_STATUS)
 default: install-cross
 
 .PHONY: install-tools
-install-tools: cross-binutils cross-gcc cross-newlib cross-gdb
+install-tools: cross-binutils cross-gcc cross-gdb
 
 .PHONY: install-cross
 install-cross: install-tools install-note

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ STATICLIBS := $(CURDIR)/build/libs/
 
 ############### BUILD RULES ###############
 
+.SECONDARY:
+
 default: install-cross
 
 .PHONY: install-tools
@@ -170,8 +172,8 @@ else
 endif
 
 multilibbash: gcc-$(GCC_VERSION)-$(CS_BASE)
-	pushd gcc-$(GCC_VERSION)-$(CS_BASE) && \
-	patch -N -p0 < ../patches/gcc-multilib-bash.patch && \
+	pushd gcc-$(GCC_VERSION)-$(CS_BASE) ; \
+	patch -N -p0 < ../patches/gcc-multilib-bash.patch ; \
 	popd ;
 
 gcc-$(GCC_VERSION)-$(CS_BASE) : $(LOCAL_BASE)/gcc-$(CS_VERSION).tar.bz2
@@ -198,36 +200,24 @@ endif
 
 gmp: gmp-$(CS_BASE)
 	mkdir -p build/gmp && cd build/gmp ; \
-	pushd ../../gmp-$(CS_BASE) ; \
-	make clean ; \
-	popd ; \
 	../../gmp-$(CS_BASE)/configure --disable-shared --prefix=$(STATICLIBS) && \
 	$(MAKE) -j$(PROCS) all && \
 	$(MAKE) install
 
 mpfr: gmp mpfr-$(CS_BASE)
 	mkdir -p build/mpfr && cd build/mpfr && \
-	pushd ../../mpfr-$(CS_BASE) ; \
-	make clean ; \
-	popd ; \
 	../../mpfr-$(CS_BASE)/configure LDFLAGS="-Wl,-search_paths_first" --disable-shared --prefix=$(STATICLIBS) --with-gmp=$(STATICLIBS) && \
 	$(MAKE) -j$(PROCS) all && \
 	$(MAKE) install
 
 mpc: mpc-$(MPC_VERSION)
 	mkdir -p build/mpc && cd build/mpc ; \
-	pushd ../../mpc-$(MPC_VERSION) ; \
-	make clean ; \
-	popd ; \
 	../../mpc-$(CS_BASE)/configure --disable-shared --prefix=$(STATICLIBS) --with-mpfr=$(STATICLIBS) --with-gmp=$(STATICLIBS) && \
 	$(MAKE) -j$(PROCS) all && \
 	$(MAKE) install
 
 cross-binutils: binutils-$(CS_BASE)
 	mkdir -p build/binutils && cd build/binutils && \
-	pushd ../../binutils-$(CS_BASE) ; \
-	make clean ; \
-	popd ; \
 	../../binutils-$(CS_BASE)/configure --prefix=$(PREFIX)		\
 	--target=$(TARGET) --with-pkgversion=$(PKG_VERSION)		\
 	--with-sysroot="$(PREFIX)/$(TARGET)" --with-bugurl=$(BUG_URL)	\
@@ -244,9 +234,6 @@ CS_SPECS='--with-specs=%{save-temps: -fverbose-asm}			\
 
 cross-gcc-first: gmp mpfr mpc cross-binutils gcc-$(GCC_VERSION)-$(CS_BASE) multilibbash
 	mkdir -p build/gcc-first && cd build/gcc-first && \
-	pushd ../../gcc-$(GCC_VERSION)-$(CS_BASE) ; \
-	make clean ; \
-	popd ; \
 	../../gcc-$(GCC_VERSION)-$(CS_BASE)/configure			\
 	--prefix=$(PREFIX) --with-pkgversion=$(PKG_VERSION)		\
 	--with-bugurl=$(BUG_URL) --target=$(TARGET) $(DEPENDENCIES)	\
@@ -295,9 +282,6 @@ endif
 
 cross-newlib: cross-binutils cross-gcc-first newlib-$(CS_BASE)
 	mkdir -p build/newlib && cd build/newlib && \
-	pushd ../../newlib-$(CS_BASE) ; \
-	make clean ; \
-	popd ; \
 	../../newlib-$(CS_BASE)/configure --prefix=$(PREFIX)	\
 	--target=$(TARGET) --disable-newlib-supplied-syscalls	\
 	--disable-libgloss --disable-nls	\
@@ -309,9 +293,6 @@ cross-newlib: cross-binutils cross-gcc-first newlib-$(CS_BASE)
 
 cross-gdb: gdb-$(CS_BASE)
 	mkdir -p build/gdb && cd build/gdb && \
-	pushd ../../gdb-$(CS_BASE) ; \
-	make clean ; \
-	popd ; \
 	../../gdb-$(CS_BASE)/configure --prefix=$(PREFIX) --target=$(TARGET) --with-pkgversion=$(PKG_VERSION) --with-bugurl=$(BUG_URL) --disable-werror && \
 	$(MAKE) -j$(PROCS) && \
 	$(MAKE) installdirs install-host install-target

--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ $(call MOD_CONFIG,gdb) : gdb-$(CS_BASE)
 
 cross-gdb: $(call MOD_CONFIG,gdb)
 	cd $(BUILD_PATH)/gdb ; \
-	$(MAKE) -j$(PROCS) && \
+	$(MAKE) -j$(PROCS) CFLAGS="-Wno-error=return-type" && \
 	$(MAKE) installdirs install-host install-target
 
 .PHONY : clean

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ gmp: $(call MOD_CONFIG,gmp)
 
 $(call MOD_CONFIG,mpfr) : gmp mpfr-$(CS_BASE)
 	mkdir -p $(BUILD_PATH)/mpfr && cd $(BUILD_PATH)/mpfr && \
-	../../mpfr-$(CS_BASE)/configure LDFLAGS="-Wl,-search_paths_first" --disable-shared --prefix=$(STATICLIBS) --with-gmp=$(STATICLIBS)
+	../../mpfr-$(CS_BASE)/configure --disable-shared --enable-static --prefix=$(STATICLIBS) --with-gmp=$(STATICLIBS)
 
 mpfr: $(call MOD_CONFIG,mpfr)
 	cd $(BUILD_PATH)/$@ ; \
@@ -231,7 +231,7 @@ mpfr: $(call MOD_CONFIG,mpfr)
 
 $(call MOD_CONFIG,mpc) : mpc-$(MPC_VERSION)
 	mkdir -p $(BUILD_PATH)/mpc && cd $(BUILD_PATH)/mpc ; \
-	../../mpc-$(CS_BASE)/configure --disable-shared --prefix=$(STATICLIBS) --with-mpfr=$(STATICLIBS) --with-gmp=$(STATICLIBS)
+	../../mpc-$(CS_BASE)/configure --disable-shared --enable-static --prefix=$(STATICLIBS) --with-mpfr=$(STATICLIBS) --with-gmp=$(STATICLIBS)
 
 mpc: $(call MOD_CONFIG,mpc)
 	cd $(BUILD_PATH)/$@ ; \


### PR DESCRIPTION
This adds incremental build support for easy debugging of compile issues. This builds upon Thomas' static gcc build and also fixes static building to work on Ubuntu 13.04 (it was a change to use --enable-static in mpfr and mpc).

I have a funny OS X machine that only has clang, the driving motivation for this, which was able to successfully to build the toolchain after making a one line modification:
- https://github.com/ndreys/gdb/blob/master/sim/arm/armsupp.c#L639
  <br> gdb has a function that is missing a return value in clang's eyes.

Edit: Silly me, I could just add a no-error CFLAG, thanks Matt!

This works well enough, and you can use ccache to fill in the gaps if for some reason something rebuilds.
