### PR TITLE
Portable location for bash, and note about using gmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@
 
 #### HIGH LEVEL/SYSTEM CONFIG OPTIONS #####
 
-SHELL   = /bin/bash
+SHELL   = /usr/bin/env bash
 UNAME  := $(shell uname)
 TARGET  = arm-none-eabi
 PREFIX ?= $(HOME)/arm-cs-tools

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ build, whether it is a previous version of this same toolchain or a
 binary toolchain from another provider.  This may end up influencing
 how newlib, in particular, gets compiled.
 
+`make` must be GNU make; on FreeBSD use `gmake` instead throughout.
+
 
 Requirements (OS X)
 -------------------

--- a/patches/gcc-multilib-bash.patch
+++ b/patches/gcc-multilib-bash.patch
@@ -2,7 +2,7 @@
 +++ gcc/genmultilib	2010-05-01 19:12:17.842723935 -0500
 @@ -1,4 +1,4 @@
 -#!/bin/sh 
-+#!/bin/bash
++#!/usr/bin/env bash
  # Generates multilib.h.
  #   Copyright (C) 1994, 1995, 1996, 1997, 1999, 2002, 2007
  #   Free Software Foundation, Inc.
@@ -11,7 +11,7 @@
  # Handle aliases
  cat >tmpmultilib3 <<\EOF
 -#!/bin/sh
-+#!/bin/bash
++#!/usr/bin/env bash
  # Output a list of aliases (including the original name) for a multilib.
  
  echo $1
@@ -20,7 +20,7 @@
  rm -f tmpmultilib
  cat >tmpmultilib <<\EOF
 -#!/bin/sh
-+#!/bin/bash
++#!/usr/bin/env bash
  # This recursive script basically outputs all combinations of its
  # input arguments, handling mutually exclusive sets of options by
  # repetition.  When the script is called, ${initial} is the list of
@@ -29,7 +29,7 @@
  if [ -n "${exceptions}" ]; then
    cat >tmpmultilib2 <<\EOF
 -#!/bin/sh
-+#!/bin/bash
++#!/usr/bin/env bash
  # This recursive script weeds out any combination of multilib
  # switches that should not be generated.  The output looks like
  # a list of subdirectory names with leading and trailing slashes.
@@ -38,7 +38,7 @@
  rm -f tmpmultilib2
  cat >tmpmultilib2 <<\EOF
 -#!/bin/sh
-+#!/bin/bash
++#!/usr/bin/env bash
  # The positional parameters are a list of matches to consider.
  # ${dirout} is the directory name and ${optout} is the current list of
  # options.


### PR DESCRIPTION
These were the changes I needed to build on FreeBSD. `/usr/bin/env bash` should work anywhere (FreeBSD installs bash in /usr/local/bin).
